### PR TITLE
Fix for dublicate radiobutton label issue

### DIFF
--- a/src/main/resources/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition/radioContent.jelly
+++ b/src/main/resources/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition/radioContent.jelly
@@ -10,7 +10,6 @@
 		    <tr id="ecp_${it.name}_${index}" style="white-space:nowrap">
 		    	<td>
 		    		<f:radio name="value" title="${value}" checked="${defaultValueMap[value] eq true}" value="${value}" json="${value}">${value}</f:radio>
-		    		<label class="attach-previous">${value}</label>
 		    	</td>
 		    </tr>	
 		    <j:set var="index" value="${index + 1}"/>


### PR DESCRIPTION
Step-by-step:
 1) create values:
![Screen Shot 2013-03-11 at 5 44 25 PM](https://f.cloud.github.com/assets/184496/243761/f1763f88-8a52-11e2-93a2-1ebd67590b10.png)

 2) press "Build now" and here they are:
![Screen Shot 2013-03-11 at 5 44 35 PM](https://f.cloud.github.com/assets/184496/243765/261ecc5a-8a53-11e2-92b5-56afd10d2622.png)
![Screen Shot 2013-03-11 at 5 48 05 PM](https://f.cloud.github.com/assets/184496/243768/4d270b78-8a53-11e2-8320-46ecb184e599.png)

3) should be:
![Screen Shot 2013-03-11 at 5 56 22 PM](https://f.cloud.github.com/assets/184496/243780/7b898d24-8a53-11e2-8651-cc6eb488fed0.png)

Fix attached in pull request. 
