### PR TITLE
Fix regressions in recent release

### DIFF
--- a/src/main/java/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition.java
@@ -151,7 +151,7 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
 			type = formData.getString("type");
 			description = formData.getString("description");
 			quoteValue = formData.getBoolean("quoteValue");
-			visibleItemCount = formData.getInt("visibleItemCount");
+			visibleItemCount = formData.optInt("visibleItemCount");
 			multiSelectDelimiter = formData.getString("multiSelectDelimiter");
 
 			JSONObject propertySourceJSON = (JSONObject)formData.get("propertySource");

--- a/src/main/resources/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition/config.jelly
+++ b/src/main/resources/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition/config.jelly
@@ -90,7 +90,7 @@
 		  <f:section title="Choose Source for Value">
 			  <f:radioBlock name="propertySource" title="Value" value="0" checked="${not empty instance.value}">
 				  <f:entry title="Value" field="propertyValue">
-				    <f:textbox />
+				    <f:textbox value="${instance.value}"/>
 				  </f:entry>
 			  </f:radioBlock>
 			  


### PR DESCRIPTION
1. Use JSONObject optInt() instead of getInt() to handle null value or
   if value is not a number.
2. Value for Property Value not loaded from config file.
