### PR TITLE
[FIXED JENKINS-23359] - Added support of URL paths to multi-level choice options

### DIFF
--- a/src/main/java/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition.java
@@ -38,6 +38,9 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import au.com.bytecode.opencsv.CSVReader;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.Reader;
 
 public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
 	private static final long serialVersionUID = -2946187268529865645L;
@@ -359,8 +362,18 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
 	
 	LinkedHashMap<String, LinkedHashSet<String>> calculateChoicesByDropdownId() throws Exception
 	{
-		List<String[]> fileLines =
-			new CSVReader(new FileReader(propertyFile), '\t').readAll();
+            Reader rdr;
+            File src = new File(propertyFile);
+            if( src.exists()) {
+                    rdr =new FileReader(src);
+            } else {             
+                URL propertyFileUrl = new URL(propertyFile);
+                rdr = new BufferedReader(
+                    new InputStreamReader(propertyFileUrl.openStream()));
+             }
+                                 
+            List<String[]> fileLines = new CSVReader(rdr, '\t').readAll();
+  
 
 		if (fileLines.size() < 2)
 		{


### PR DESCRIPTION
The proposed change is just a hotfix. As any other file operation in the plugin, it requires additional stream handling to prevent errors and resource leaks.

Signed-off-by: Oleg Nenashev <o.v.nenashev@gmail.com>