### PR TITLE
Switched rootURL to resURL for static resources.

### DIFF
--- a/src/main/resources/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition/jsonContent.jelly
+++ b/src/main/resources/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition/jsonContent.jelly
@@ -33,12 +33,12 @@
 	   (function() {
 	       var mapping = {
 	            html: '',
-	            bootstrap2: '${rootURL}/plugin/extended-choice-parameter/css/bootstrap.min.css',
-	            bootstrap3: '${rootURL}/plugin/extended-choice-parameter/css/bootstrap.min.css',
-	            foundation3: '${rootURL}/plugin/extended-choice-parameter/css/foundation3.css',
-	            foundation4: '${rootURL}/plugin/extended-choice-parameter/css/foundation4.css',
-	            foundation5: '${rootURL}/plugin/extended-choice-parameter/css/foundation5.css',
-	            jqueryui: '${rootURL}/plugin/extended-choice-parameter/css/jquery-ui.css'
+	            bootstrap2: '${resURL}/plugin/extended-choice-parameter/css/bootstrap.min.css',
+	            bootstrap3: '${resURL}/plugin/extended-choice-parameter/css/bootstrap.min.css',
+	            foundation3: '${resURL}/plugin/extended-choice-parameter/css/foundation3.css',
+	            foundation4: '${resURL}/plugin/extended-choice-parameter/css/foundation4.css',
+	            foundation5: '${resURL}/plugin/extended-choice-parameter/css/foundation5.css',
+	            jqueryui: '${resURL}/plugin/extended-choice-parameter/css/jquery-ui.css'
            };
 	       
 	       document.getElementById('theme_stylesheet').href = mapping['${theme}'];
@@ -49,10 +49,10 @@
 	  <j:if test="${not empty iconlib}">
        (function() {
            var mapping = {
-                foundation2:  '${rootURL}/plugin/extended-choice-parameter/css/general_foundicons.css',
-                foundation3:  '${rootURL}/plugin/extended-choice-parameter/css/foundation-icons.css',
-                fontawesome3: '${rootURL}/plugin/extended-choice-parameter/css/font-awesome3.css',
-                fontawesome4: '${rootURL}/plugin/extended-choice-parameter/css/font-awesome4.css'
+                foundation2:  '${resURL}/plugin/extended-choice-parameter/css/general_foundicons.css',
+                foundation3:  '${resURL}/plugin/extended-choice-parameter/css/foundation-icons.css',
+                fontawesome3: '${resURL}/plugin/extended-choice-parameter/css/font-awesome3.css',
+                fontawesome4: '${resURL}/plugin/extended-choice-parameter/css/font-awesome4.css'
            };
            
            document.getElementById('icon_stylesheet').href = mapping['${iconlib}'];

--- a/src/main/resources/com/cwctravel/hudson/plugins/extended_choice_parameter/JSONEditorPageDecorator/header.jelly
+++ b/src/main/resources/com/cwctravel/hudson/plugins/extended_choice_parameter/JSONEditorPageDecorator/header.jelly
@@ -12,13 +12,13 @@
         };
      }  
    </script>     
-   <script type="text/javascript" src="${rootURL}/plugin/extended-choice-parameter/js/selectize.min.js"></script>
-   <script type="text/javascript" src="${rootURL}/plugin/extended-choice-parameter/js/jsoneditor.min.js"></script>   
-   <script type="text/javascript" src="${rootURL}/plugin/extended-choice-parameter/js/jquery.jsonview.min.js"></script>
+   <script type="text/javascript" src="${resURL}/plugin/extended-choice-parameter/js/selectize.min.js"></script>
+   <script type="text/javascript" src="${resURL}/plugin/extended-choice-parameter/js/jsoneditor.min.js"></script>
+   <script type="text/javascript" src="${resURL}/plugin/extended-choice-parameter/js/jquery.jsonview.min.js"></script>
   
-   <link rel="stylesheet" href="${rootURL}/plugin/extended-choice-parameter/css/jquery.jsonview.css" />
-   <link rel='stylesheet' id='icon_stylesheet' href="${rootURL}/plugin/extended-choice-parameter/css/selectize.css"></link>   
-   <link rel='stylesheet' id='icon_stylesheet' href="${rootURL}/plugin/extended-choice-parameter/css/selectize.bootstrap2.css"></link>   
+   <link rel="stylesheet" href="${resURL}/plugin/extended-choice-parameter/css/jquery.jsonview.css" />
+   <link rel='stylesheet' id='icon_stylesheet' href="${resURL}/plugin/extended-choice-parameter/css/selectize.css"></link>
+   <link rel='stylesheet' id='icon_stylesheet' href="${resURL}/plugin/extended-choice-parameter/css/selectize.bootstrap2.css"></link>
    <link rel='stylesheet' id='theme_stylesheet'></link>
    <link rel='stylesheet' id='icon_stylesheet'></link>   
 </j:jelly>


### PR DESCRIPTION
Switched rootURL to resURL for static resources.  This allows the resources to be cached by the browser.  See here:  https://wiki.jenkins.io/display/JENKINS/Basic+guide+to+Jelly+usage+in+Jenkins#BasicguidetoJellyusageinJenkins-PredefinedURLs

