### PR TITLE
[JENKINS-60619] Java 11 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+.settings/*
 .idea/*
 *.iml
 /target/
 /work/
+/.classpath
+/.project

--- a/pom.xml
+++ b/pom.xml
@@ -43,11 +43,6 @@
             <artifactId>script-security</artifactId>
             <version>1.19</version>
         </dependency>
-        <dependency>
-            <groupId>io.fastjson</groupId>
-            <artifactId>boon</artifactId>
-            <version>0.34</version>
-        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition.java
@@ -1458,7 +1458,7 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
 		return result;
 	}
 
-	public Object getJSONEditorOptions() {
+	public JSONObject getJSONEditorOptions() {
 		Object result = null;
 		try {
 			String script = null;
@@ -1474,7 +1474,7 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
 		catch(IOException | URISyntaxException e) {
 			LOGGER.log(Level.SEVERE, e.getMessage(), e);
 		}
-		return result;
+		return (JSONObject) result;
 	}
 
 	private String expandVariables(String input) {

--- a/src/main/java/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition.java
@@ -718,7 +718,6 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
 
 	private Object executeGroovyScript(String groovyScript, String bindings, String groovyClasspath) throws URISyntaxException, IOException {
 		Object groovyValue = null;
-
 		if(checkScriptApproval(groovyScript, groovyClasspath, false)) {
 			GroovyShell groovyShell = getGroovyShell(groovyClasspath);
 			GroovyCodeSource codeSource = new GroovyCodeSource(groovyScript, computeMD5Hash(groovyScript), "/groovy/shell");
@@ -1458,8 +1457,8 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
 		return result;
 	}
 
-	public JSONObject getJSONEditorOptions() {
-		Object result = null;
+	public Object getJSONEditorOptions() {
+	    Object result = null;
 		try {
 			String script = null;
 			if(!StringUtils.isBlank(groovyScript)) {
@@ -1468,13 +1467,12 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
 			else {
 				script = Util.loadFile(new File(expandVariables(groovyScriptFile)));
 			}
-
 			result = executeGroovyScript(script, bindings, groovyClasspath);
 		}
 		catch(IOException | URISyntaxException e) {
 			LOGGER.log(Level.SEVERE, e.getMessage(), e);
 		}
-		return (JSONObject) result;
+		return result;
 	}
 
 	private String expandVariables(String input) {

--- a/src/main/resources/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition/jsonContent.jelly
+++ b/src/main/resources/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition/jsonContent.jelly
@@ -13,17 +13,13 @@
   <input id="editor_${it.name}_value" type="hidden" name="value" />
   
   <j:set var="jsonEditorOptions" value="${it.getJSONEditorOptions()}"/>
-  <j:set var="theme" value="${jsonEditorOptions.get('theme')}"/>
-  <j:set var="iconlib" value="${jsonEditorOptions.get('iconlib')}"/>
-  
-  <j:invokeStatic var="jsonEditorOptionsJSON" className="org.boon.Boon" method="toJson">
-    <j:arg value="${jsonEditorOptions}" type="java.lang.Object" />
-  </j:invokeStatic>
+  <j:set var="theme" value="${jsonEditorOptions.optString('theme')}"/>
+  <j:set var="iconlib" value="${jsonEditorOptions.optString('iconlib')}"/>
   
   <j:set  var="jsonEditorScript" value="${it.getJSONEditorScript()}"/>
     
   <script>       
-      var editor_${normalizedParameterName} = new JSONEditor(document.getElementById('editor_${it.name}_holder'), ${jsonEditorOptionsJSON});
+      var editor_${normalizedParameterName} = new JSONEditor(document.getElementById('editor_${it.name}_holder'), ${jsonEditorOptions});
   
       editor_${normalizedParameterName}.on('change',function() {
 		  document.getElementById("editor_${it.name}_value").value = JSON.stringify(editor_${normalizedParameterName}.getValue());
@@ -62,7 +58,7 @@
       <j:if test="${not empty jsonEditorScript}">
         (function(editor, valueInput) {            
         	<j:out value="${jsonEditorScript}"/>
-        })(editor_${normalizedParameterName}, document.getElementById("editor_${it.name}_value"));
+        })(editor_${normalizedParameterName});
       </j:if>
   </script>
 

--- a/src/main/resources/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition/jsonContent.jelly
+++ b/src/main/resources/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition/jsonContent.jelly
@@ -13,13 +13,17 @@
   <input id="editor_${it.name}_value" type="hidden" name="value" />
   
   <j:set var="jsonEditorOptions" value="${it.getJSONEditorOptions()}"/>
-  <j:set var="theme" value="${jsonEditorOptions.optString('theme')}"/>
-  <j:set var="iconlib" value="${jsonEditorOptions.optString('iconlib')}"/>
+  <j:set var="theme" value="${jsonEditorOptions.get('theme')}"/>
+  <j:set var="iconlib" value="${jsonEditorOptions.get('iconlib')}"/>
   
+  <j:invokeStatic var="jsonEditorOptionsJSON" className="groovy.json.JsonOutput" method="toJson">
+    <j:arg value="${jsonEditorOptions}" type="java.lang.Object" />
+  </j:invokeStatic>
+
   <j:set  var="jsonEditorScript" value="${it.getJSONEditorScript()}"/>
     
   <script>       
-      var editor_${normalizedParameterName} = new JSONEditor(document.getElementById('editor_${it.name}_holder'), ${jsonEditorOptions});
+      var editor_${normalizedParameterName} = new JSONEditor(document.getElementById('editor_${it.name}_holder'), ${jsonEditorOptionsJSON});
   
       editor_${normalizedParameterName}.on('change',function() {
 		  document.getElementById("editor_${it.name}_value").value = JSON.stringify(editor_${normalizedParameterName}.getValue());
@@ -56,9 +60,9 @@
       </j:if>
       
       <j:if test="${not empty jsonEditorScript}">
-        (function(editor, valueInput) {            
+        (function(editor, valueInput) {
         	<j:out value="${jsonEditorScript}"/>
-        })(editor_${normalizedParameterName});
+        })(editor_${normalizedParameterName}, document.getElementById("editor_${it.name}_value"));
       </j:if>
   </script>
 


### PR DESCRIPTION
[JENKINS-60619](https://issues.jenkins-ci.org/browse/JENKINS-60619)

Boon library used by the plugin to parse JSON is not compatible with JDK 11.
This PR remove Boon library from the plugin and use groovy.json.* parser.
 
In your script you don't have to call Boon library anymore : 

Before : 
```
import org.boon.Boon;

def jsonEditorOptions = Boon.fromJson(/{...}/);
```

After : 
```
def jsonEditorOptions = new groovy.json.JsonSlurper().parseText(/{...}/);
```