### PR TITLE
[JENKINS-63931] change section to advanced tag for ExtendedChoiceParameterDefinition

### DIFF
--- a/src/main/resources/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition/config.jelly
+++ b/src/main/resources/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition/config.jelly
@@ -89,7 +89,7 @@
 	        <f:checkbox checked="${instance.quoteValue}"/>
 	      </f:entry>
           
-      <f:section title="Choose Source for Value">
+      <f:advanced title="Choose Source for Value">
           <f:radioBlock name="propertySource" title="Value" value="0" checked="${parameterType eq 'basic' and empty instance.propertyFile and not empty instance.value}">
               <f:entry title="Value" field="propertyValue">
                 <f:textbox value="${instance.value}"/>
@@ -132,9 +132,9 @@
                   </f:entry>                  
               </f:advanced>
           </f:radioBlock>
-      </f:section>
+      </f:advanced>
               
-	  <f:section title="Choose Source for Default Value">
+	  <f:advanced title="Choose Source for Default Value">
 	      <f:radioBlock name="defaultPropertySource" title="Default Value" value="0" checked="${parameterType eq 'basic' and not empty instance.defaultValue}">
 	        <f:entry field="defaultPropertyValue">
 	            <f:textbox value="${instance.defaultValue}"/>
@@ -177,9 +177,9 @@
                   </f:entry>   	              
 	          </f:advanced>
 	      </f:radioBlock>
-	  </f:section>  
+	  </f:advanced>
 	  
-      <f:section title="Choose Source for Value Description">
+      <f:advanced title="Choose Source for Value Description">
           <f:radioBlock name="descriptionPropertySource" title="Description" value="0" checked="${parameterType eq 'basic' and not empty instance.descriptionPropertyValue}">
             <f:entry field="descriptionPropertyValue">
                 <f:textbox value="${instance.descriptionPropertyValue}"/>
@@ -222,7 +222,7 @@
                   </f:entry>                  
               </f:advanced>
           </f:radioBlock>
-      </f:section>   
+      </f:advanced>
   </f:radioBlock>
   <f:radioBlock name="parameterGroup" title="Multi-level Parameter Types" value="1" checked="${parameterType eq 'multilevel'}">
         <f:entry name="type" title="Parameter Type" field="type">


### PR DESCRIPTION
[JENKINS-63931] change section to advanced tag for ExtendedChoiceParameterDefinition

try to  fixup jenkins job configure section shows unnecessary tabs