### PR TITLE
Remove generated warning

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,15 +6,6 @@ link:https://github.com/jenkinsci/extended-choice-parameter-plugin/graphs/contri
 link:https://plugins.jenkins.io/extended-choice-parameter/[image:https://img.shields.io/jenkins/plugin/i/extended-choice-parameter.svg?color=blue&label=installations[Jenkins Plugin Installs]]
 link:https://plugins.jenkins.io/extended-choice-parameter/[image:https://img.shields.io/jenkins/plugin/v/extended-choice-parameter.svg[Plugin]]
 
-[WARNING]
-.Security issues
-====
-Older versions of this plugin may not be safe to use.  Please review the following warnings before
-using an older version:
-
-* https://jenkins.io/security/advisory/2017-04-10/[Arbitrary code execution
-  vulnerability]
-====
 
 Add extended functionality to Choice parameter
 


### PR DESCRIPTION
This was generated by a macro on the wiki, now the plugin site takes care of showing warnings as appropriate.