### PR TITLE
add trim for descriptionPropertyValue

### DIFF
--- a/src/main/java/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition.java
@@ -499,7 +499,7 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
         String[] descriptionPropertyValues =
             StringUtils.split(effectiveDescriptionPropertyValue, ',');
         for (int i = 0; i < values.length && i < descriptionPropertyValues.length; i++) {
-          descriptionPropertyValueMap.put(values[i], descriptionPropertyValues[i]);
+          descriptionPropertyValueMap.put(StringUtils.trim(values[i]), StringUtils.trim(descriptionPropertyValues[i]));
         }
       }
     }


### PR DESCRIPTION
try to fix https://github.com/jenkinsci/extended-choice-parameter-plugin/issues/81

for selectContent.jelly  <j:forEach var="value" items="${effectiveValue}"> this will be trim by jelly tag forEach.

for computeDefaultValue this will be trim by method computeDefaultValueMap

but descriptionPropertyValue was not trim.

Change-Id: Ic05be1679436d7c6c80c4d585a301acfbeaa5cc7

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
