### PR TITLE
Use library plugins where possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,26 @@
       <groupId>com.opencsv</groupId>
       <artifactId>opencsv</artifactId>
       <version>5.7.1</version>
+      <exclusions>
+        <!-- Provided by commons-lang3-api plugin -->
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
+        <!-- Provided by commons-text-api plugin -->
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-text</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-lang3-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-text-api</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Implement dynamic linking by adding plugin-to-plugin dependencies on shared library plugins rather than statically linking these JARs into the plugin JPI.

### Testing done

`mvn clean verify -Dtest=InjectedTest`, inspected JPI to see that extra JARs were removed