### PR TITLE
[JENKINS-57125] Trim the value and request parameter options

### DIFF
--- a/src/main/java/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition.java
@@ -529,7 +529,7 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
       if (valueStr != null) {
         List<String> result = new ArrayList<>();
 
-        String[] values = valueStr.split(",\\s*");
+        String[] values = valueStr.trim().split("\\s*,\\s*");
         Set<String> valueSet = new HashSet<>(Arrays.asList(values));
 
         for (String requestValue : requestValues) {

--- a/src/main/java/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition.java
@@ -529,12 +529,12 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
       if (valueStr != null) {
         List<String> result = new ArrayList<>();
 
-        String[] values = valueStr.split(",");
+        String[] values = valueStr.split(",\\s*");
         Set<String> valueSet = new HashSet<>(Arrays.asList(values));
 
         for (String requestValue : requestValues) {
-          if (valueSet.contains(requestValue)) {
-            result.add(requestValue);
+          if (valueSet.contains(requestValue.trim())) {
+            result.add(requestValue.trim());
           }
         }
 


### PR DESCRIPTION
### Relevant Issues

- https://issues.jenkins.io/browse/JENKINS-57125
- https://github.com/jenkinsci/extended-choice-parameter-plugin/issues/99

<!-- Please describe your pull request here. -->

The reason for this issue is because the plugin's function splits the `valueStr` by commas (`,`) and does not account for possible spaces between them.

```java
String valueStr = "option1, option2, option3, option4";
String[] values = valueStr.split(); // ["option1", " option2", " option3", " option4"]
```

Notice the space prefix in the strings. Because of this when a parameter is passed using `/buildWithParameters` without the space prefix, it gets ignored.

```
[POST] /buildWithParameters?parameter=option1&parameter=option2
```

Here `option1` gets accepted, however `option2` gets ignored. To solve this I've split the `valueStr` by commas and taken spaces into consideration. Additionally I have also trimmed the values that are passed by the user.

### Workaround

The temporary solution is to remove all the spaces from the options string in the job configuration, if that isn't possible you can pass the value to the endpoint along with the space (`%20`) as shown below.

```
[POST] /buildWithParameters?parameter=option1&parameter=%20option2
```

### Testing done

1. Create a project with an Extend Choice Parameter of type Multi Select. Set the value as a string separated by commas and be sure to include spaces.
    <img width="941" alt="Screenshot 2024-04-25 at 16 15 36" src="https://github.com/jenkinsci/extended-choice-parameter-plugin/assets/60378235/6f4764fe-7618-41d0-8844-b248a2bcb09f">
2. To test this I was initially getting a `No valid crumb was included` error while trying to make a POST request, so I [disabled CSRF protection](https://unix.stackexchange.com/a/582764) to get around this.
3. Trigger a build from the API endpoint with this key, I've done this using the `curl` command.
    ```sh
    curl http://localhost:5000/jenkins/job/Test%20Pipeline/buildWithParameters --data parameter=option1 --data parameter=option2
    ```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
